### PR TITLE
Add composer and more flexibilities 

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ effort into trying to make this a generically useful class.
   element from `$node` up and returns the first tag it finds. This logic may not exactly jibe with how tags are intended
   to work in IDML; it does what I need it to do for my project but may not work for you. The tag it returns is
   `urldecode()`ed.
-- `saveAll($zip_filepath)`: Save all the files in the IDML. There are individual save methods for saving various pieces but why
+- `saveAll($zip_file_path)`: Save all the files in the IDML. There are individual save methods for saving various pieces but why
   bother? Just use this one.
 
 Everything else you'll just have to figure out on your own.

--- a/README.md
+++ b/README.md
@@ -12,13 +12,18 @@ an `.idml` package is a chore. This helps a bit. (A *bit*.)
 Instantiate the object:
 
     require __DIR__.'/../vendor/autoload.php';
-    $idml = new \IDML\Package("filename.idml");
+    $idml = new \IDML\Package();
+    $idml->setZip("filename.idml")
+    $idml->load();
 
 This will unzip `filename.idml` to a directory called `.filename.idml`. This directory will be deleted when the object
 is garbage-collected (see the `__destruct()` method). Alternatively, if you keep your IDMLs stored unzipped, a directory
 can also be passed to the constructor:
 
-    $idml = new \IDML\Package("/path/to/idml/");
+    require __DIR__.'/../vendor/autoload.php';
+    $idml = new \IDML\Package();
+    $idml->setDirectory("/path/to/idml/");
+    $idml->load();
 
 This directory will not be deleted upon object destruction. (Admittedly this is not a typical use-case but happened to
 be how the project I was working on stored things.)
@@ -27,7 +32,7 @@ The `IDML\Package` object is essentially a file manager/server of `DOMDocument` 
 That's most of what this class does.
 
     $spreads = $idml->getSpreads();
-    $storyu12a = $idml->getStories("u12a");
+    $storyu12a = $idml->getStorie("u12a");
     $backingStory = $idml->getBackingStory();
     // etc
 
@@ -61,7 +66,7 @@ effort into trying to make this a generically useful class.
   element from `$node` up and returns the first tag it finds. This logic may not exactly jibe with how tags are intended
   to work in IDML; it does what I need it to do for my project but may not work for you. The tag it returns is
   `urldecode()`ed.
-- `saveAll()`: Save all the files in the IDML. There are individual save methods for saving various pieces but why
+- `saveAll($zip_filepath)`: Save all the files in the IDML. There are individual save methods for saving various pieces but why
   bother? Just use this one.
 
 Everything else you'll just have to figure out on your own.

--- a/README.md
+++ b/README.md
@@ -3,24 +3,28 @@
 A simple class to handle file management of Adobe InDesign IDML files. Keeping track of all the individual files within
 an `.idml` package is a chore. This helps a bit. (A *bit*.)
 
+### Installation
+
+    composer require prometee/php-idml    
+
 #### Usage
 
 Instantiate the object:
 
-    require_once "IDMLPackage.php";
-    $idml = new \IDMLPackage\IDMLPackage("filename.idml");
+    require __DIR__.'/../vendor/autoload.php';
+    $idml = new \IDML\Package("filename.idml");
 
 This will unzip `filename.idml` to a directory called `.filename.idml`. This directory will be deleted when the object
 is garbage-collected (see the `__destruct()` method). Alternatively, if you keep your IDMLs stored unzipped, a directory
 can also be passed to the constructor:
 
-    $idml = new \IDMLPackage\IDMLPackage("/path/to/idml/");
+    $idml = new \IDML\Package("/path/to/idml/");
 
 This directory will not be deleted upon object destruction. (Admittedly this is not a typical use-case but happened to
 be how the project I was working on stored things.)
 
-The `IDMLPackge` object is essentially a file manager/server of `DOMDocument` objects for all the internal files. That's
-most of what this class does.
+The `IDML\Package` object is essentially a file manager/server of `DOMDocument` objects for all the internal files.
+That's most of what this class does.
 
     $spreads = $idml->getSpreads();
     $storyu12a = $idml->getStories("u12a");

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,28 @@
+{
+	"name": "prometee/php-idml",
+	"description": "A simple class to handle file management of Adobe InDesign IDML files.",
+	"type": "library",
+	"license": "MIT",
+	"repositories": [
+		{
+			"type": "git",
+			"url": "https://github.com/Prometee/php-idml.git"
+		}
+	],
+    "authors": [
+        {
+            "name": "Francis Hilaire",
+            "email": "prometee@gmail.com",
+            "homepage": "http://francishilaire.fr"
+        }
+    ],
+	"require": {
+		"php": ">=5.4.0",
+		"ext-zip": "*"
+	},
+    "autoload": {
+        "psr-4": {
+            "IDML\\": "src"
+        }
+    }
+}

--- a/src/Exception/Error.php
+++ b/src/Exception/Error.php
@@ -1,0 +1,32 @@
+<?php
+// Copyright © 2016-2017 Zandr Martin
+
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+// OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+namespace IDML\Exception;
+
+use \Exception;
+
+/**
+ * Generic exception class thrown when any error is encountered within the
+ * IDML\Package class.
+ */
+class Error extends Exception {
+
+}

--- a/src/Package.php
+++ b/src/Package.php
@@ -641,10 +641,10 @@ class Package {
 
     /**
      * Saves all of the individual documents in the IDML package to their documentURI locations.
-     * @param null|string $zip_filepath
+     * @param null|string $zip_file_path
      * @return $this
      */
-    public function saveAll($zip_filepath = null) {
+    public function saveAll($zip_file_path = null) {
         $this->saveDesignMap()
             ->saveStories()
             ->saveMasterSpreads()
@@ -661,9 +661,9 @@ class Package {
             }
         }
 
-        $zip_filepath = $zip_filepath ? $zip_filepath : ($this->isZip() ? $this->getZip() : null);
-        if ($zip_filepath) {
-            $this->zipPackage($zip_filepath);
+        $zip_file_path = $zip_file_path ? $zip_file_path : ($this->isZip() ? $this->getZip() : null);
+        if ($zip_file_path) {
+            $this->zipPackage($zip_file_path);
         }
 
         return $this;
@@ -671,24 +671,24 @@ class Package {
 
     /**
      * Zip this package into an IDML file from its component parts.
-     * @param string|null $zip_filepath [optional] If supplied, this is the filename of the zipped package. If not supplied,
+     * @param string|null $zip_file_path [optional] If supplied, this is the filename of the zipped package. If not supplied,
      * this defaults to the name of the directory of this IDML package with a ".idml" extension.
      * @return $this
      */
-    public function zipPackage($zip_filepath = null) {
+    public function zipPackage($zip_file_path = null) {
         $currentDirectory = getcwd();
         chdir($this->getDirectory());
 
-        if (!$zip_filepath) {
+        if (!$zip_file_path) {
             if ($this->isZip()) {
-                $zip_filepath = basename($this->getZip());
+                $zip_file_path = basename($this->getZip());
             } else {
-                $zip_filepath = basename($this->getDirectory()) . self::IDML_FILENAME_EXTENSION;
+                $zip_file_path = basename($this->getDirectory()) . self::IDML_FILENAME_EXTENSION;
             }
         }
 
         $zip = new ZipArchive();
-        $zip->open($zip_filepath, ZipArchive::CREATE);
+        $zip->open($zip_file_path, ZipArchive::CREATE);
         $dir = new SplFileInfo(".");
 
         // this is included here to make this class standalone, but ideally
@@ -715,7 +715,7 @@ class Package {
         }
 
         $zip->close();
-        $this->setZip($zip_filepath);
+        $this->setZip($zip_file_path);
         chdir($currentDirectory);
         return $this;
     }


### PR DESCRIPTION
Hello,

I need your library for a project, but there is some features that we need to get enhanced to be well with our projects, like when we use composer for exemple.
So I make this modifications :
- move all used externals classes to a use statement (now we know exactly what's the dependencies of your library)
- all the missing or not defined PHPDoc blocks have been updated or created (checked by PHPStorm)
- rename the namespace (Too much repetitions)
- move each classes into differents single file to fit the recommandations of PHP Standards Recommendations (PSR).
- create a packagist.org project for composer (feel free to create your own) to get easy autoload and easy install for project with frameworks or not.
-  simplify some getters for 3 array of attributes
- add some error check
- add some flexibilities to set the path of the unzipped file (in case that we are on a read only file system for exemple)
 - update the doc

You can test the code with this composer.json for exemple :
`{
    "require": {
      "prometee/php-idml": "*"
    },
    "minimum-stability": "dev"
}`

Then make a
`composer install`

Enjoy !